### PR TITLE
docs: add devplan for discord-context runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Instructions
+
+- Track future development steps in `docs/devplans/`.
+- Add new dev plans there as features evolve.

--- a/docs/devplans/discord-openhands-context.md
+++ b/docs/devplans/discord-openhands-context.md
@@ -1,0 +1,30 @@
+---
+title: Execute Prompts with Discord and Repository Context
+---
+
+## Goal
+Enable the bot to execute any prompt using both the current Discord channel context and the repository contents, running within the OpenHands runtime on Kubernetes and leveraging the Codex API.
+
+## Plan
+1. **Kubernetes Runtime Setup**
+   - Deploy the OpenHands runtime to the Kubernetes cluster.
+   - Configure persistent storage for cloning and updating the active repository per request.
+
+2. **Discord Context Integration**
+   - Implement a service that receives events/messages from Discord channels.
+   - Collect recent channel history and pass it as contextual input when executing prompts.
+
+3. **Repository Mounting**
+   - For each request, mount or sync the referenced repository into the runtime.
+   - Ensure changes made by the agent are persisted back to the repository's run workspace.
+
+4. **Codex API Execution**
+   - Forward combined context (Discord messages + repository files) to the Codex API for code generation or command execution.
+   - Stream Codex responses back to the Discord channel.
+
+5. **Microagent Support**
+   - If the bot cannot fulfill a request, trigger an OpenHands microagent tailored to the required domain or workflow.
+
+6. **Next Steps Tracking**
+   - Track refinements and implementation tasks in this `docs/devplans` directory.
+


### PR DESCRIPTION
## Summary
- add devplan for executing prompts with Discord and repository context on OpenHands runtime using Codex API
- note in AGENTS.md to track next steps in docs/devplans

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e4a1426948326b720e5125d17e167